### PR TITLE
Refact wok simulation to use general component sim class

### DIFF
--- a/simulation/components/__init__.py
+++ b/simulation/components/__init__.py
@@ -1,7 +1,7 @@
 import abc
 import threading
 import time
-from typing import Any
+from typing import Any, Type, List, Dict
 
 import colorlog
 from transitions import Machine
@@ -23,13 +23,13 @@ class ComponentSim(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def transitions(self):
+    def transitions(self) -> List[Dict]:
         """The transitions for the finite state machine"""
         return []
 
     @property
     @abc.abstractmethod
-    def states(self):
+    def states(self) -> Type[Any]:
         """The states for the finite state machine"""
         return []
 

--- a/simulation/components/runner_sim.py
+++ b/simulation/components/runner_sim.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Union, Dict, List
 
 from components import ComponentSim
 from messages.main_controller_message import ComponentCodes, ComponentReceiveResponses
@@ -18,7 +18,9 @@ class SauceContainer:
 
     """
 
-    def __init__(self, sauce_id, sauce_name, capacity=200, current_capacity=None):
+    def __init__(
+        self, sauce_id, sauce_name, capacity=200, current_capacity=None
+    ) -> None:
         """Constructor
 
         Args:
@@ -86,7 +88,6 @@ class RunnerSim(ComponentSim):
         )
 
         # Sauce Runner attributes
-        self.sauce_type = None
         self.sauce_containers = dict(
             [
                 (i, SauceContainer(sauce_id=i, sauce_name=f"Sauce #{i}"))
@@ -144,7 +145,7 @@ class RunnerSim(ComponentSim):
     """
 
     @property
-    def _request_handlers(self):
+    def _request_handlers(self) -> Dict:
         """Request handlers"""
         # Grab general component request handlers
         general_component_request_handlers = super()._request_handlers
@@ -165,7 +166,7 @@ class RunnerSim(ComponentSim):
         return runner_request_handlers
 
     @property
-    def _receive_handlers(self):
+    def _receive_handlers(self) -> Dict:
         """Receiving handlers"""
         return {
             RunnerRequestCodes.SET_TARGET_WOK: self._set_target_wok,
@@ -304,7 +305,9 @@ class RunnerSim(ComponentSim):
         self._is_wok_ready = True
         return ComponentReceiveResponses.CONFIRMED
 
-    def _get_sauce_bag_status(self, sauce_container_id: int):
+    def _get_sauce_bag_status(
+        self, sauce_container_id: int
+    ) -> Union[ComponentReceiveResponses, int]:
         """Handler Main Controller request 12"""
         # Container not found
         if sauce_container_id not in self.sauce_containers:
@@ -406,11 +409,11 @@ class RunnerSim(ComponentSim):
     """
 
     @property
-    def states(self):
+    def states(self) -> RunnerStates:
         return RunnerStates
 
     @property
-    def transitions(self):
+    def transitions(self) -> List[Dict]:
         # The transitions for the finite state machine
         transitions = [
             {
@@ -502,7 +505,7 @@ class RunnerSim(ComponentSim):
             self.go_to_standby()
 
     @property
-    def _state_actions(self):
+    def _state_actions(self) -> Dict:
         """Actions to execute in each states"""
         return {
             RunnerStates.STANDBY: self._standby_state_actions,

--- a/simulation/components/runner_sim.py
+++ b/simulation/components/runner_sim.py
@@ -1,4 +1,4 @@
-from typing import Union, Dict, List
+from typing import Union, Dict, List, Type
 
 from components import ComponentSim
 from messages.main_controller_message import ComponentCodes, ComponentReceiveResponses
@@ -408,7 +408,7 @@ class RunnerSim(ComponentSim):
     """
 
     @property
-    def states(self) -> RunnerStates:
+    def states(self) -> Type[RunnerStates]:
         return RunnerStates
 
     @property

--- a/simulation/components/runner_sim.py
+++ b/simulation/components/runner_sim.py
@@ -130,7 +130,7 @@ class RunnerSim(ComponentSim):
         self.start()
 
     def _reset(self, data=None) -> ComponentReceiveResponses:
-        """when Wok naturally goes back to STANDBY state"""
+        """when Runner naturally goes back to STANDBY state"""
         # Reset operation attributes
         self._target_wok = None
         self._desire_sauce_id = None
@@ -319,7 +319,6 @@ class RunnerSim(ComponentSim):
         # Get sauce bag status
         return self.sauce_containers[sauce_container_id].current_capacity
 
-    # Not able to set wok ready while not in SENDING state
     """
     Physical functions
     """
@@ -516,7 +515,7 @@ class RunnerSim(ComponentSim):
         }
 
     def _standby_state_actions(self) -> None:
-        self._release_code = RunnerRequestCodes.NO_REQUEST
+        self._request_code = RunnerRequestCodes.NO_REQUEST
         if self._target_wok is None:
             self._request_code = RunnerRequestCodes.SET_TARGET_WOK
         elif self._desire_sauce_id is None:
@@ -525,7 +524,7 @@ class RunnerSim(ComponentSim):
             self._request_code = RunnerRequestCodes.SET_RELEASE_VOLUME
 
     def _sending_state_actions(self) -> None:
-        self._release_code = RunnerRequestCodes.NO_REQUEST
+        self._request_code = RunnerRequestCodes.NO_REQUEST
         if not self._is_wok_ready:
             self._request_code = RunnerRequestCodes.SET_WOK_IS_READY
 

--- a/simulation/components/wok_sim.py
+++ b/simulation/components/wok_sim.py
@@ -76,16 +76,6 @@ class WokSim(ComponentSim):
             WokRequestCodes.SET_WOK_IS_EMPTY: self._set_wok_is_empty,
         }
 
-    def request(self, request_code, data=0) -> int:
-        """Got request from main controller"""
-        response = ComponentReceiveResponses.DENIED
-
-        if request_code in self._request_handlers:
-            request_handler = self._request_handlers[request_code]
-            response = request_handler(data)
-
-        return response
-
     def _get_component_code(self, data) -> ComponentCodes:
         """Handle request code 1"""
         return ComponentCodes.WOK

--- a/simulation/components/wok_sim.py
+++ b/simulation/components/wok_sim.py
@@ -1,0 +1,487 @@
+import time
+from typing import Dict, List
+
+from components import ComponentSim
+from messages.main_controller_message import ComponentCodes, ComponentReceiveResponses
+from messages.wok_message import (
+    WokStates,
+    WokRequestCodes,
+    MasterWokRequestCodes,
+    WokErrors,
+)
+
+
+class WokSim(ComponentSim):
+    """This is the simulation of the wok component powered by an Arduino"""
+
+    def __init__(self, id) -> None:
+        super().__init__(
+            component_id=id,
+            component_code=ComponentCodes.WOK,
+            initial_state=WokStates.WAITING_ORDER,
+        )
+
+        # Wok attributes
+        self._real_wok_degrees = 23
+
+        # Operation attributes
+        self._order_id = None
+        self._heat_degrees = None
+        self._cook_seconds = None
+        self._ingredients_ready = False
+        self._drop_done = False
+        self._clean_done = False
+
+        self._preheat_start_degrees = None
+        self._cook_start_time = None
+        self._cooked_seconds = 0
+        self._last_cook_iteration_check_time = 0
+        self._startup = True
+
+        # WokSim loop Thread
+        self._reset()
+        self.start()
+
+    """
+    Wok Input/Output functions
+    """
+
+    @property
+    def _request_handlers(self) -> Dict:
+        """Request handlers"""
+        # Grab general component request handlers
+        general_component_request_handlers = super()._request_handlers
+
+        # Wok special requests
+        wok_request_handlers = {
+            MasterWokRequestCodes.RESET_WOK: self._reset,
+            MasterWokRequestCodes.RESET_HEAT_TEMPERATURE: self._set_heat_degrees,
+            MasterWokRequestCodes.RESET_COOKING_TIME: self._set_cook_seconds,
+            MasterWokRequestCodes.RECONFIG_WOK: self._reconfig,
+            MasterWokRequestCodes.FORCE_DISPENSE: self._force_dispense,
+        }
+
+        # Combines all handlers
+        wok_request_handlers.update(general_component_request_handlers)
+        return wok_request_handlers
+
+    @property
+    def _receive_handlers(self) -> Dict:
+        """Receiving handlers"""
+        return {
+            WokRequestCodes.SET_ORDER_ID: self._set_order_id,
+            WokRequestCodes.SET_HEAT_DEGREES: self._set_heat_degrees,
+            WokRequestCodes.SET_COOK_SECONDS: self._set_cook_seconds,
+            WokRequestCodes.SET_INGREDIENTS_READY: self._set_ingredients_ready,
+            WokRequestCodes.SET_WOK_IS_EMPTY: self._set_wok_is_empty,
+        }
+
+    def request(self, request_code, data=0) -> int:
+        """Got request from main controller"""
+        response = ComponentReceiveResponses.DENIED
+
+        if request_code in self._request_handlers:
+            request_handler = self._request_handlers[request_code]
+            response = request_handler(data)
+
+        return response
+
+    def _get_component_code(self, data) -> ComponentCodes:
+        """Handle request code 1"""
+        return ComponentCodes.WOK
+
+    def _get_state_code(self, data) -> WokStates:
+        """Handle request code 2"""
+        return WokStates(self.state)
+
+    def _get_error_code(self, data) -> WokErrors:
+        """Handle request code 3"""
+        return WokErrors(self._error_code)
+
+    def _get_request_code(self, data) -> WokRequestCodes:
+        """Handle request code 4"""
+        return WokRequestCodes(self._request_code)
+
+    def _save_data_handler(self, data) -> ComponentReceiveResponses:
+        """Handle request code 5"""
+        response = ComponentReceiveResponses.DENIED
+        if self._request_code in self._receive_handlers:
+            receive_handler = self._receive_handlers[self._request_code]
+            response = receive_handler(data)
+            # with self._transition_lock:
+            #     self._transit_state()
+        return response
+
+    def _reset(self, data=None) -> ComponentReceiveResponses:
+        """Handle request code 6 or when Wok naturally goes back to WAITING ORDER state"""
+
+        # If reset by master
+        if data is not None:
+            if self.is_COOKING():
+                self.error_code = WokErrors.COOK_TERMINATED_BEFORE_DONE
+                self.log.error(f"WokSim #{self.id} {self.error_code.get_description()}")
+                # return WokReceiveResponses.DENIED # TODO: Need to clarify how to recover from error
+                self.reset()
+
+        # Reset operation attributes
+        self._order_id = None
+
+        return self._reconfig(data=data)
+
+    def _reconfig(self, data=None) -> ComponentReceiveResponses:
+        """Handle request code 9"""
+
+        # Check state
+        if self.is_DISPENSING_FOOD() or (self.is_CLEANING() and not self._clean_done):
+            self.error_code = WokErrors.NOT_ABLE_TO_RECONFIG
+            self.log.error(f"WokSim #{self.id} {self.error_code.get_description()}")
+            return ComponentReceiveResponses.DENIED
+
+        # Reset operation attributes
+        self._heat_degrees = None
+        self._cook_seconds = None
+        self._ingredients_ready = False
+        self._drop_done = False
+
+        self._preheat_start_degrees = None
+        self._cook_start_time = None
+        self._cooked_seconds = 0
+        self._last_cook_iteration_check_time = 0
+        self._last_cook_iteration_time = None
+
+        # Go to WAITING ORDER if not naturally reconfigure request from the Main Controller
+        if not (self.is_CLEANING() and self._clean_done) and not self._startup:
+            self.reconfig()
+            self.log.warning(
+                f"WokSim #{self.id} reconfigured (erase cooking time and temperature)"
+            )
+
+        self._clean_done = False
+        self._startup = False
+
+        return ComponentReceiveResponses.CONFIRMED
+
+    def _force_dispense(self, data=None) -> ComponentReceiveResponses:
+        """Handle request code 10"""
+        if self.is_COOKING():
+            self.log.warning(f"WokSim #{self.id} been forced to dispense dish")
+            self._cook_seconds = 0
+            return ComponentReceiveResponses.CONFIRMED
+
+        self.error_code = WokErrors.NOT_ABLE_TO_RECONFIG
+        self.log.error(f"WokSim #{self.id} {self.error_code.get_description()}")
+        return ComponentReceiveResponses.DENIED
+
+    def _set_order_id(self, o_id: str) -> ComponentReceiveResponses:
+        """Handler data that requested by Wok request 1"""
+        self._order_id = o_id
+        self.log.info(
+            f"WokSim #{self.id} set an order to cook (Order ID: {self._order_id}) "
+            f"Temperature: {self._heat_degrees}C, Cook for {self._cook_seconds} seconds."
+        )
+        return ComponentReceiveResponses.CONFIRMED
+
+    def _set_heat_degrees(self, degrees: int) -> ComponentReceiveResponses:
+        """Handler data that requested by Wok request 2 and Main Controller request 7"""
+        # Not able to set heat degree while not in WAITING ORDER, WAITING INGREDIENT, or COOKING state
+        if not (
+            self.is_WAITING_ORDER() or self.is_WAITING_INGREDIENT() or self.is_COOKING()
+        ):
+            self.log.error(
+                f"WokSim #{self.id} not able to set temperature while in {self.state.name} state"
+            )
+            return ComponentReceiveResponses.DENIED
+
+        # If resetting heat degrees (only at Main Controller request 7)
+        if self._heat_degrees:
+            self.log.warning(
+                f"WokSim #{self.id} cooking temperature reset to {degrees} C (was {self._heat_degrees} C)."
+            )
+
+        self._heat_degrees = degrees
+        return ComponentReceiveResponses.CONFIRMED
+
+    def _set_cook_seconds(self, duration: int) -> ComponentReceiveResponses:
+        """Handler data that requested by Wok request 3 and Main Controller request 8"""
+        # Not able to set cooking duration while not in WAITING ORDER, WAITING INGREDIENT, or COOKING state
+        if not (
+            self.is_WAITING_ORDER() or self.is_WAITING_INGREDIENT() or self.is_COOKING()
+        ):
+            self.log.error(
+                f"WokSim #{self.id} not able to set cook duration while in {self.state.name} state"
+            )
+            return ComponentReceiveResponses.DENIED
+
+        # If resetting cook duration (only at Main Controller request 8)
+        if self._cook_seconds:
+            self.log.warning(
+                f"WokSim #{self.id} cooking time reset to {duration} seconds (was {self._cook_seconds} seconds)."
+            )
+
+        self._cook_seconds = duration
+        return ComponentReceiveResponses.CONFIRMED
+
+    def _set_ingredients_ready(
+        self, is_ingredients_ready: bool
+    ) -> ComponentReceiveResponses:
+        """Handler data that requested by Wok request 4"""
+        self._ingredients_ready = is_ingredients_ready
+        return ComponentReceiveResponses.CONFIRMED
+
+    def _set_wok_is_empty(self, is_wok_empty: bool) -> ComponentReceiveResponses:
+        """Handler data that requested by Wok request 5"""
+        self._drop_done = is_wok_empty
+        return ComponentReceiveResponses.CONFIRMED
+
+    """
+    Physical functions
+    """
+
+    @property
+    def _is_temperature_set(self) -> bool:
+        """Check if preheat is done"""
+        if (
+            self._heat_degrees
+            and abs(self._heat_degrees - self._real_wok_degrees) < 0.5
+        ):
+            return True
+        return False
+
+    def _adjust_wok_temperature(self) -> None:
+        """Simulate pre-heat Wok to configured cooking temperature"""
+
+        # Not able to pre-heat if not configured cooking temperature
+        if not self._heat_degrees:
+            self.log.error(
+                f"WokSim #{self.id} can't pre-heat without cooking temperature configured."
+            )
+            return
+
+        # Do nothing if pre-heat is achieve
+        if self._is_temperature_set:
+            return
+
+        # Set pre-heating monitoring when start cooking
+        if not self._preheat_start_degrees:
+            self._preheat_start_degrees = self._real_wok_degrees
+
+        # Updates while pre-heating
+        if self._real_wok_degrees > self._heat_degrees:
+            self._real_wok_degrees -= 1
+        else:
+            self._real_wok_degrees += 1
+
+        current_delta_degrees = self._heat_degrees - self._real_wok_degrees
+        full_delta_degrees = self._heat_degrees - self._preheat_start_degrees
+        if current_delta_degrees % (full_delta_degrees // 5) == 0:
+            self.log.info(
+                f"WokSim #{self.id} adjusting temperature (current temperature {self._real_wok_degrees} C, "
+                f"target {self._heat_degrees} C)"
+            )
+
+    def _cook(self) -> None:
+        """Simulate Wok while cooking"""
+        now = time.time()
+
+        # Set cooking monitoring when start cooking
+        if not self._cook_start_time:
+            self._cook_start_time = now
+            self._cooked_seconds = 0
+            self._last_cook_iteration_check_time = now
+
+        # Set last cook iteration time to now if it's None
+        if not self._last_cook_iteration_time:
+            self._last_cook_iteration_time = now
+
+        # Adjust temperature if it's not set
+        if not self._is_temperature_set:
+            self._adjust_wok_temperature()
+            self._last_cook_iteration_time = None
+            return
+
+        # Updates while cooking
+        self._cooked_seconds += now - self._last_cook_iteration_time
+        self._last_cook_iteration_time = now
+
+        # Logs
+        check_delta = now - self._last_cook_iteration_check_time
+        if check_delta > self._cook_seconds // 5:
+            remaining_seconds = self._cook_seconds - self._cooked_seconds
+            self.log.info(
+                f"WokSim #{self.id} cooking ... Cooked {self._cooked_seconds:.2f} seconds, "
+                f"{remaining_seconds:.2f} seconds remaining."
+            )
+            self._last_cook_iteration_check_time = now
+
+    def _drop_dish_to_bowl(self) -> None:
+        """Simulate Wok dispensing food to bowl"""
+        self.log.info(f"WokSim #{self.id} dropping dish to bowl ...")
+
+    def _clean_wok(self) -> None:
+        """Simulate Wok cleaning"""
+        self.log.info(f"WokSim #{self.id} cleaning ...")
+        self._clean_done = True
+        self.log.info(f"WokSim #{self.id} cleaning done. Waiting order again.")
+
+    """
+    Wok Operations logic functions
+    """
+
+    @property
+    def states(self) -> WokStates:
+        return WokStates
+
+    @property
+    def transitions(self) -> List[Dict]:
+        """The transitions for the finite state machine"""
+        transitions = [
+            {
+                "trigger": "configured_order",
+                "source": WokStates.WAITING_ORDER,
+                "dest": WokStates.WAITING_INGREDIENT,
+            },
+            {
+                "trigger": "cook",
+                "source": WokStates.WAITING_INGREDIENT,
+                "dest": WokStates.COOKING,
+            },
+            {
+                "trigger": "cook_done",
+                "source": WokStates.COOKING,
+                "dest": WokStates.DISPENSING_FOOD,
+                "after": "_drop_dish_to_bowl",
+            },
+            {
+                "trigger": "clean",
+                "source": WokStates.DISPENSING_FOOD,
+                "dest": WokStates.CLEANING,
+            },
+            {
+                "trigger": "reconfig",
+                "source": [
+                    WokStates.WAITING_ORDER,
+                    WokStates.WAITING_INGREDIENT,
+                    WokStates.COOKING,
+                ],
+                "dest": WokStates.WAITING_ORDER,
+            },
+            {
+                "trigger": "reset",
+                "source": "*",
+                "dest": WokStates.WAITING_ORDER,
+                "before": "_reset",
+            },
+        ]
+        return transitions
+
+    def _transit_state(self) -> None:
+        """The logic of state transition
+
+        1. The Wok will initialize in the `WAITING ORDER` state, which will
+            - Wait for the main controller to set the cooking heat temperature.
+            - Heat the Wok to the temperature configured.
+            - Wait for the main controller to set cooking duration in seconds.
+            - Wait for the main controller to pass down the order id.
+        2. After the above parameters are set, the Wok goes into the `waiting ingredients` state which will
+            - Wait for the main controller to notify if the ingredients are in the Wok.
+        3. Once the main controller confirm the ingredients have been put in the Wok, it goes into the
+        `cooking` state which will
+            - Heat the Wok to the temperature configured and cook for the duration in seconds previously set.
+        4. Once the cooking time has passed, the Wok will enter the `dispensing food` state which will
+            - Drop the Wok content (food) into the bowl.
+        5. Finally, the Wok will go to the `cleaning` state after dropping the dish into a bowl. It will
+            - Clean itself
+        6. The Wok will cycle back to the first step
+
+        """
+
+        # If Wok is configured if the order id, cook duration, and temperature are set (point 1 and 2)
+        if (
+            self.is_WAITING_ORDER()
+            and self._real_wok_degrees
+            and self._is_temperature_set
+            and self._cook_seconds
+            and self._order_id
+        ):
+            self.configured_order()
+
+        # If Wok has ingredients ready then start to cook (point 3)
+        elif self.is_WAITING_INGREDIENT() and self._ingredients_ready:
+            self.cook()
+
+        # If Wok done cooking when the cooked time is mare than configured cook duration (point 4)
+        elif (
+            self.is_COOKING() and self._cooked_seconds >= self._cook_seconds
+            if self._cook_seconds is not None
+            else 0
+        ):
+            self.cook_done()
+
+        # Wok can start cleaning once it's empty (point 5)
+        elif self.is_DISPENSING_FOOD() and self._drop_done:
+            self.clean()
+
+        # Wok can reset to WAITING ORDER state once it done cleaning (point 6)
+        elif self.is_CLEANING() and self._clean_done:
+            self.reset()
+
+    @property
+    def _state_actions(self) -> Dict:
+        """Actions to execute in each states"""
+        return {
+            WokStates.WAITING_ORDER: self._waiting_order_state_actions,
+            WokStates.WAITING_INGREDIENT: self._waiting_ingredient_state_actions,
+            WokStates.COOKING: self._cooking_state_actions,
+            WokStates.DISPENSING_FOOD: self._dispensing_food_state_actions,
+            WokStates.CLEANING: self._cleaning_state_actions,
+        }
+
+    def _waiting_order_state_actions(self) -> None:
+        """Actions while WAITING ORDER state"""
+        # Update Wok request code
+        self._request_code = WokRequestCodes.NO_REQUEST
+        self._request_code = (
+            WokRequestCodes.SET_ORDER_ID if not self._order_id else self._request_code
+        )
+        self._request_code = (
+            WokRequestCodes.SET_COOK_SECONDS
+            if not self._cook_seconds
+            else self._request_code
+        )
+        self._request_code = (
+            WokRequestCodes.SET_HEAT_DEGREES
+            if not self._heat_degrees
+            else self._request_code
+        )
+
+        # If temperature configured pre-heat the Wok
+        if self._heat_degrees:
+            self._adjust_wok_temperature()
+
+    def _waiting_ingredient_state_actions(self) -> None:
+        """Actions while WAITING INGREDIENTS state"""
+        # Update Wok request code
+        self._request_code = (
+            WokRequestCodes.SET_INGREDIENTS_READY
+            if not self._ingredients_ready
+            else WokRequestCodes.NO_REQUEST
+        )
+
+    def _cooking_state_actions(self) -> None:
+        """Actions while COOKING state"""
+        # Cook dish
+        self._cook()
+
+    def _dispensing_food_state_actions(self) -> None:
+        """Actions while WAITING INGREDIENTS state"""
+        # Update Wok request code
+        self._request_code = (
+            WokRequestCodes.SET_WOK_IS_EMPTY
+            if not self._drop_done
+            else WokRequestCodes.NO_REQUEST
+        )
+
+    def _cleaning_state_actions(self) -> None:
+        """Actions while WAITING INGREDIENTS state"""
+        # Clean the Wok
+        self._clean_wok()

--- a/simulation/components/wok_sim.py
+++ b/simulation/components/wok_sim.py
@@ -1,5 +1,5 @@
 import time
-from typing import Dict, List
+from typing import Dict, List, Type
 
 from components import ComponentSim
 from messages.main_controller_message import ComponentCodes, ComponentReceiveResponses
@@ -318,7 +318,7 @@ class WokSim(ComponentSim):
     """
 
     @property
-    def states(self) -> WokStates:
+    def states(self) -> Type[WokStates]:
         return WokStates
 
     @property

--- a/simulation/interfaces/wok_sim_interface.py
+++ b/simulation/interfaces/wok_sim_interface.py
@@ -1,0 +1,260 @@
+import logging
+import time
+from argparse import ArgumentParser, Namespace
+from enum import Enum
+from typing import Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from starlette import status
+from starlette.responses import JSONResponse
+
+from components.wok_sim import WokSim
+from messages.main_controller_message import ComponentReceiveResponses
+from messages.wok_message import (
+    WokStates,
+    WokRequestCodes,
+    MasterWokRequestCodes,
+    WokErrors,
+)
+
+log = logging.getLogger(f"Wok Simulation API")
+log.setLevel(logging.DEBUG)
+
+pi_sim = APIRouter()
+woks = []
+wok_num = 2
+
+
+def argparser_setup(arg_parser: ArgumentParser) -> ArgumentParser:
+    arg_parser.add_argument("--wok-num", default=2, type=int)
+    return arg_parser
+
+
+async def startup_event(args: Namespace):
+    global woks, wok_num
+    wok_num = args.wok_num
+    woks = [WokSim(id=wok_id + 1) for wok_id in range(wok_num)]
+    log.info(f"{len(woks)} Wok simulation(s) has been initialized.")
+
+
+async def shutdown_event():
+    for wok in woks:
+        wok.stop()
+    log.info(f"{len(woks)} Wok simulation(s) has been triggered to turned off.")
+
+
+def get_wok_by_id(wok_id: int):
+    if wok_id - 1 not in range(len(woks)):
+        log.error(f"Wok #{wok_id} does not exists.")
+        return None
+    return woks[wok_id - 1]
+
+
+class ErrorResponse(Enum):
+    """The error responses for the simulation interaction endpoints"""
+
+    @staticmethod
+    def wok_not_found(wok_id: int):
+        """Wok does not exist"""
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"Error": f"Wok #{wok_id} not found."},
+        )
+
+    @staticmethod
+    def method_not_allow(wok_id: int, message: str):
+        """Method not allow"""
+        return JSONResponse(
+            status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
+            content={"Error": f"Wok #{wok_id} {message}."},
+        )
+
+
+class WokConfig(BaseModel):
+    cooking_time: Optional[int]
+    cooking_temperature: Optional[int]
+    order_id: Optional[str]
+
+
+@pi_sim.put("/{wok_id}")
+async def config_cooking(wok_id: int, wok_config: WokConfig):
+    # Get the specific Wok by id
+    wok = get_wok_by_id(wok_id)
+    if wok is None:
+        return ErrorResponse.wok_not_found(wok_id)
+
+    # Check if in waiting order state
+    if wok.request(MasterWokRequestCodes.GET_STATE_CODE) != WokStates.WAITING_ORDER:
+        return JSONResponse(
+            status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
+            content={
+                "Error": f"To set [cooking_temperature, cooking_time, order_id] the Wok #{wok_id}, "
+                f"has to be in STATE: {WokStates.WAITING_ORDER.name}."
+            },
+        )
+
+    # Handle API call
+    response = ""
+
+    # Set cooking temperature
+    if wok_config.cooking_temperature:
+        wok_raw_response = wok.request(
+            MasterWokRequestCodes.RESET_HEAT_TEMPERATURE,
+            data=wok_config.cooking_temperature,
+        )
+        wok_response = ComponentReceiveResponses(wok_raw_response)
+        if wok_response == ComponentReceiveResponses.CONFIRMED:
+            response += (
+                f"Cooking temperature has been successfully set to {wok_config.cooking_temperature} "
+                f"celsius degrees. "
+            )
+        else:
+            response += (
+                f"Failed to set temperature to {wok_config.cooking_temperature} ℃. "
+            )
+            log.error(response)
+
+    # Set cooking time cooking time
+    if wok_config.cooking_time:
+        wok_raw_response = wok.request(
+            MasterWokRequestCodes.RESET_COOKING_TIME, data=wok_config.cooking_time
+        )
+        wok_response = ComponentReceiveResponses(wok_raw_response)
+        if wok_response == ComponentReceiveResponses.CONFIRMED:
+            response += f"Cooking time has been successfully set to {wok_config.cooking_time} seconds. "
+        else:
+            response += (
+                f"Failed to set a cooking time to {wok_config.cooking_time} seconds. "
+            )
+            log.error(response)
+
+    # Set order ID
+    if wok_config.order_id:
+        time.sleep(1)  # wait 1 seconds to see if wok request order ID
+        if (
+            wok.request(MasterWokRequestCodes.GET_REQUEST_CODE)
+            == WokRequestCodes.SET_ORDER_ID
+        ):
+            wok_raw_response = wok.request(
+                MasterWokRequestCodes.RESPOND_REQUEST, data=wok_config.order_id
+            )
+            wok_response = ComponentReceiveResponses(wok_raw_response)
+            if wok_response == ComponentReceiveResponses.CONFIRMED:
+                response += (
+                    f"Order ID has been set successfully to {wok_config.order_id}. "
+                )
+            else:
+                response += f"Failed to set order id to {wok_config.order_id}. "
+                log.error(response)
+        else:
+            response += (
+                f"Not albe to set Order ID to {wok_config.order_id} since it already been set or "
+                f"cooking time and/or temperature haven't been set. "
+            )
+            log.error(response)
+
+    return {"Wok response": response}
+
+
+@pi_sim.get("/{wok_id}/state")
+async def get_wok_state(wok_id: int):
+    # Get the specific Wok by id
+    wok = get_wok_by_id(wok_id)
+    if wok is None:
+        return ErrorResponse.wok_not_found(wok_id)
+
+    # Handle API call
+    wok_raw_response = wok.request(MasterWokRequestCodes.GET_STATE_CODE)
+    wok_state = WokStates(wok_raw_response)
+    return {"Wok state": f"{wok_state.name}"}
+
+
+@pi_sim.put("/{wok_id}/state")
+async def transit_wok_state(wok_id: int, dest_state: WokStates):
+    # Get the specific Wok by id
+    wok = get_wok_by_id(wok_id)
+    if wok is None:
+        return ErrorResponse.wok_not_found(wok_id)
+
+    # Get the current wok state
+    current_state = WokStates(wok.request(MasterWokRequestCodes.GET_STATE_CODE))
+
+    # Reconfigure
+    if dest_state == WokStates.WAITING_ORDER and current_state in [
+        WokStates.WAITING_ORDER,
+        WokStates.WAITING_INGREDIENT,
+        WokStates.COOKING,
+    ]:
+        master_request_code = MasterWokRequestCodes.RECONFIG_WOK
+        response = f"reconfigure Wok #{wok_id} (erased cooking time and temperature)."
+
+    # Force dispense
+    elif dest_state == WokStates.DISPENSING_FOOD and current_state == WokStates.COOKING:
+        master_request_code = MasterWokRequestCodes.FORCE_DISPENSE
+        response = f"force dispense Wok #{wok_id}."
+
+    # Set ingredients is ready
+    elif (
+        current_state == WokStates.WAITING_INGREDIENT
+        and dest_state == WokStates.COOKING
+        and wok.request(MasterWokRequestCodes.GET_REQUEST_CODE)
+        == WokRequestCodes.SET_INGREDIENTS_READY
+    ):
+        master_request_code = MasterWokRequestCodes.RESPOND_REQUEST
+        response = f"notify Wok #{wok_id} that ingredients are ready."
+
+    # Set wok is empty
+    elif (
+        current_state == WokStates.DISPENSING_FOOD
+        and dest_state == WokStates.CLEANING
+        and wok.request(MasterWokRequestCodes.GET_REQUEST_CODE)
+        == WokRequestCodes.SET_WOK_IS_EMPTY
+    ):
+        master_request_code = MasterWokRequestCodes.RESPOND_REQUEST
+        response = f"notify Wok #{wok_id} that wok is empty."
+
+    # Method not allow
+    else:
+        return ErrorResponse.method_not_allow(
+            wok_id,
+            f"not able to transit to {dest_state.name} state while in {current_state.name} state.",
+        )
+
+    # Perform wok operation through I2C
+    wok_raw_response = wok.request(
+        master_request_code, data=ComponentReceiveResponses.CONFIRMED
+    )
+    wok_response = ComponentReceiveResponses(wok_raw_response)
+    if wok_response == ComponentReceiveResponses.CONFIRMED:
+        response = f"Successfully {response}"
+    else:
+        response = f"Failed to {response}"
+
+    return {"Wok response": response}
+
+
+@pi_sim.get("/{wok_id}/error")
+async def get_wok_error(wok_id: int):
+    # Get the specific Wok by id
+    wok = get_wok_by_id(wok_id)
+    if wok is None:
+        return ErrorResponse.wok_not_found(wok_id)
+
+    # Handle API call
+    wok_raw_response = wok.request(MasterWokRequestCodes.GET_ERROR_CODE)
+    wok_error = WokErrors(wok_raw_response)
+    return {"Wok error": f"{wok_error.get_description()}"}
+
+
+@pi_sim.get("/{wok_id}/request")
+async def get_wok_request(wok_id: int):
+    # Get the specific Wok by id
+    wok = get_wok_by_id(wok_id)
+    if wok is None:
+        return ErrorResponse.wok_not_found(wok_id)
+
+    # Handle API call
+    wok_raw_response = wok.request(MasterWokRequestCodes.GET_REQUEST_CODE)
+    wok_request = WokRequestCodes(wok_raw_response)
+    return {"Wok request": f"{wok_request.get_description()}"}

--- a/simulation/messages/runner_message.py
+++ b/simulation/messages/runner_message.py
@@ -70,7 +70,7 @@ class RunnerErrors(IntEnum):
     NOT_ABLE_TO_RETRIEVE = 2
 
     def get_description(self):
-        # The Wok error code and description map
+        # The error code and description map
         err_desc = {
             self.NO_ERROR: "no error",
             self.NEED_REFILL: "need refill",

--- a/simulation/messages/wok_message.py
+++ b/simulation/messages/wok_message.py
@@ -1,0 +1,82 @@
+"""The Wok related messages"""
+from enum import IntEnum, auto
+
+from messages import EnhanceEnum, OKComponentCodeEnum, CodeDescMap
+from messages.main_controller_message import MASTER_COMPONENT_REQ_DESC_MAP
+
+"""
+Main Controller to Runner messages
+"""
+
+MASTER_WOK_REQ_DESC_MAP = CodeDescMap(
+    RESET_WOK="request to reset Wok",
+    RESET_HEAT_TEMPERATURE="request to reset Wok heating temperature",
+    RESET_COOKING_TIME="request to reset Wok cooking duration",
+    RECONFIG_WOK="request to reconfigure Wok (reset cooking time and temperature)",
+    FORCE_DISPENSE="request to force dispense dish",
+)
+
+MasterWokRequestCodes = OKComponentCodeEnum(
+    "MasterWokRequestCodes",
+    list(MASTER_COMPONENT_REQ_DESC_MAP) + list(MASTER_WOK_REQ_DESC_MAP),
+)
+MasterWokRequestCodes.set_description(
+    MASTER_COMPONENT_REQ_DESC_MAP + MASTER_WOK_REQ_DESC_MAP
+)
+
+
+class WokRequestCodes(IntEnum):
+    """The request code from Wok to Main controller"""
+
+    NO_REQUEST = 0
+    SET_HEAT_DEGREES = auto()
+    SET_COOK_SECONDS = auto()
+    SET_ORDER_ID = auto()
+    SET_INGREDIENTS_READY = auto()
+    SET_WOK_IS_EMPTY = auto()
+
+    def get_description(self):
+        request_desc = {
+            self.NO_REQUEST: "No request from Wok",
+            self.SET_ORDER_ID: "Wok request order ID",
+            self.SET_HEAT_DEGREES: "Wok request to set cooking temperature",
+            self.SET_COOK_SECONDS: "Wok request to set cook time in seconds",
+            self.SET_INGREDIENTS_READY: "Wok request to confirm whether ingredients are in Wok",
+            self.SET_WOK_IS_EMPTY: "Wok request to confirm whether the wok in empty",
+        }
+        wok_request_code = self.value
+        return request_desc.get(
+            wok_request_code, f"No description for Wok request code {wok_request_code}"
+        )
+
+
+class WokErrors(IntEnum):
+
+    NO_ERROR = 0
+    COOK_TERMINATED_BEFORE_DONE = 1  # Cooking terminates before cooking time complete
+    BOWL_NO_READY = 2  # The bowl is not in place for dish exporting
+    NOT_ABLE_TO_RECONFIG = 3
+    NOT_ABLE_TO_DISPENSE = 4
+
+    def get_description(self):
+        # The Wok error code and description map
+        err_desc = {
+            self.NO_ERROR: "no error",
+            self.COOK_TERMINATED_BEFORE_DONE: "cooking terminates before cooking time complete",
+            self.BOWL_NO_READY: "the bowl is not in place for dish exporting",
+            self.NOT_ABLE_TO_RECONFIG: "not able to reconfig at current state",
+            self.NOT_ABLE_TO_DISPENSE: "not able to dispense dish at current state",
+        }
+        err_code = self.value
+        return err_desc.get(err_code, f"No description for Error {err_code}")
+
+
+class WokStates(IntEnum, EnhanceEnum):
+    """Wok states"""
+
+    # ERROR = 255
+    WAITING_ORDER = auto()
+    WAITING_INGREDIENT = auto()
+    COOKING = auto()
+    DISPENSING_FOOD = auto()
+    CLEANING = auto()

--- a/simulation/sim_api.py
+++ b/simulation/sim_api.py
@@ -4,7 +4,7 @@ import logging
 import uvicorn
 from fastapi import FastAPI
 
-from interfaces import runner_sim_interface
+from interfaces import runner_sim_interface, wok_sim_interface
 
 app = FastAPI(
     title="Open Kitchen Simulation",
@@ -17,27 +17,30 @@ log = logging.getLogger(f"Simulation API")
 
 @app.on_event("startup")
 async def startup_event():
+    await wok_sim_interface.startup_event(args)
     await runner_sim_interface.startup_event(args)
     log.info(f"Open-Kitchen simulation has been initialized.")
 
 
 @app.on_event("shutdown")
 async def shutdown_event():
+    await wok_sim_interface.shutdown_event()
     await runner_sim_interface.shutdown_event()
     log.info(f"Open-Kitchen simulation has been triggered to turn off.")
 
 
 if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser()
+    wok_sim_interface.argparser_setup(arg_parser)
     runner_sim_interface.argparser_setup(arg_parser)
     args = arg_parser.parse_args()
 
-    # app.include_router(
-    #     wok_sim_interface.router,
-    #     prefix="/wok",
-    #     tags=["wok"],
-    #     responses={404: {"description": "Not found"}},
-    # )
+    app.include_router(
+        wok_sim_interface.pi_sim,
+        prefix="/wok",
+        tags=["wok"],
+        responses={404: {"description": "Not found"}},
+    )
     app.include_router(
         runner_sim_interface.runner_pi_sim,
         prefix="/runner",


### PR DESCRIPTION
Changes,
- Refactor wok simulation to use general component sim class
- Add refactored wok to sim CLI and API interfaces
- Fix some Python typing prompt mistakes
- Improve sim CLI by displaying the master request description 

To test,
1. Activate the dev virtual environment
2. Go to <repo>/simulation directory.
3. Using CLI to interact with simulations, run
  ```bash
  python sim_cli --component {wok,runner}
  ```
4. Using API to interact with simulations, run the flowing command. Then, go to `http://127.0.0.1:8000/docs` to play with the simulations,
  ```bash
  python sim_api [--wok-num WOK_NUM] [--sauce-bag-num SAUCE_BAG_NUM]
  ```
 